### PR TITLE
fix file collision on case-insensitive systems

### DIFF
--- a/modules/site/src/main/scala/golfclash/notebook/page/courses.scala
+++ b/modules/site/src/main/scala/golfclash/notebook/page/courses.scala
@@ -28,7 +28,7 @@ package page
 object courses {
 
   val init = () => {
-    hole.init()
+    map.init()
   }
 
 }

--- a/modules/site/src/main/scala/golfclash/notebook/page/map.scala
+++ b/modules/site/src/main/scala/golfclash/notebook/page/map.scala
@@ -34,7 +34,7 @@ import golfclash.notebook.core._
 import markedjs._
 import monix.execution.Scheduler.Implicits.global
 
-object hole {
+object map {
 
   var PageHoleData    = none[HoleData]
   var CurrentHoleNote = none[HoleNote]

--- a/modules/site/src/main/scala/golfclash/notebook/page/tournaments.scala
+++ b/modules/site/src/main/scala/golfclash/notebook/page/tournaments.scala
@@ -28,7 +28,7 @@ package page
 object tournaments {
 
   val init = () => {
-    hole.init()
+    map.init()
   }
 
 }


### PR DESCRIPTION
I believe this should take care of #359 , it looked simplier to rename `hole.scala` and fix these two errors than to mess with `Hole.scala`