### PR TITLE
Koh Hong Resort replaced The Oasis in Tour 7

### DIFF
--- a/modules/site/src/main/resources/microsite/data/tours/07.yaml
+++ b/modules/site/src/main/resources/microsite/data/tours/07.yaml
@@ -2,7 +2,7 @@ number: 7
 tourName: Tropic Kings
 courses:
   - name: Santa Ventura
-  - name: The Oasis
+  - name: Koh Hong Resort
   - name: Sunshine Glades
 description: >
   Help Wanted


### PR DESCRIPTION
The app doesn't show The Oasis anymore and is instead using Koh Hong Resort.